### PR TITLE
Some minor fixes (#481)

### DIFF
--- a/effect_envelope.cpp
+++ b/effect_envelope.cpp
@@ -61,7 +61,7 @@ void AudioEffectEnvelope::noteOn(void)
 void AudioEffectEnvelope::noteOff(void)
 {
 	__disable_irq();
-	if (state != STATE_IDLE && state != STATE_FORCED) {
+	if (state != STATE_RELEASE && state != STATE_IDLE && state != STATE_FORCED) {
 		state = STATE_RELEASE;
 		count = release_count;
 		inc_hires = (-mult_hires) / (int32_t)count;

--- a/effect_granular.h
+++ b/effect_granular.h
@@ -21,6 +21,9 @@
  * SOFTWARE.
  */
 
+#ifndef _effect_granular_h_
+#define _effect_granular_h_
+
 #include <AudioStream.h> // github.com/PaulStoffregen/cores/blob/master/teensy4/AudioStream.h
 
 class AudioEffectGranular : public AudioStream
@@ -63,3 +66,4 @@ private:
 	bool sample_req;
 };
 
+#endif // _effect_granular_h_

--- a/effect_reverb.cpp
+++ b/effect_reverb.cpp
@@ -222,15 +222,17 @@ AudioEffectReverb::update(void)
 {
   audio_block_t *block;
 
-  if (!(block = receiveWritable()))
-    return;
-
-  if (!block->data)
-    return;
+  if (nullptr == (block = receiveWritable()))
+  {
+	if (nullptr == (block = allocate()))
+		return;
+	else
+		memset(block->data,0,sizeof block->data);
+  }
 
   arm_q15_to_q31(block->data, q31_buf, AUDIO_BLOCK_SAMPLES);
   provide_guard_bits_q31(q31_buf, AUDIO_BLOCK_SAMPLES, 8);
-  
+
   _do_comb_apf(&apf[0], q31_buf, q31_buf);
   _do_comb_apf(&apf[1], q31_buf, q31_buf);
 


### PR DESCRIPTION
- effect_envelope.cpp: don't re-start release if noteOff() call in release phase
- effect_granular.h: add guard macros
- effect_reverb.cpp: don't just return on NULL block received, process silent data (otherwise the reverb cuts off in a nasty fashion...)